### PR TITLE
Fix las-assets import

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can visit http://localhost:9100 to see the application.
 
 ### general documentation
 
-This repository was created as part of the evaluation project "single page application (SPA) and rest oriented client architecture (RoCA)". [More information] (http://lvm-it.github.io) 
+This repository was created as part of the evaluation project "single page application (SPA) and resource-oriented client architecture (RoCA)". [More information] (http://lvm-it.github.io)
 
 
 ## Deutsche Version
@@ -35,4 +35,4 @@ Sie finden die Anwendung unter http://localhost:9100.
 
 ### Allgemeine Dokumentation
 
-Dieses Projekt ist entstanden im Rahmen einer Evaluation der Architekturen Single Page Application (SPA) und rest oriented client architecture (ROCA). Weitere Informationen befinden sich [hier] (http://lvm-it.github.io)
+Dieses Projekt ist entstanden im Rahmen einer Evaluation der Architekturen Single Page Application (SPA) und resource-oriented client architecture (ROCA). Weitere Informationen befinden sich [hier] (http://lvm-it.github.io)

--- a/frontend/index.less
+++ b/frontend/index.less
@@ -2,4 +2,4 @@
 @font-path: '/assets/fonts/';
 
 // Import LVM LAS Assets
-@import "npm://lvm-las-assets/src/styles/main.less";
+@import "npm://lvm-las-assets/index.less";


### PR DESCRIPTION
This PR fixes a problem with stylesheet compilation during build step. Currently `public/application.css` won't be created due a wrong less import.

Furthermore it corrects the faulty ROCA-acronym (this should be also fixed in the others roca-repos).